### PR TITLE
refactor: old-react FP review pass + dark-mode form polish

### DIFF
--- a/src/components/SourceCode/index.jsx
+++ b/src/components/SourceCode/index.jsx
@@ -10,20 +10,20 @@ class SourceCode extends PureComponent {
     className: PropTypes.string,
     lanugage: PropTypes.string,
     label: PropTypes.string,
-    open: PropTypes.bool,
+    defaultOpen: PropTypes.bool,
   }
 
   static defaultProps = {
     className: '',
     label: 'source',
-    open: false,
+    defaultOpen: false,
   }
 
   constructor(props) {
     super(props)
 
     this.state = {
-      open: props.open
+      open: props.defaultOpen,
     }
   }
 

--- a/src/components/SourceCode/index.jsx
+++ b/src/components/SourceCode/index.jsx
@@ -8,7 +8,7 @@ import styles from './index.css'
 class SourceCode extends PureComponent {
   static propTypes = {
     className: PropTypes.string,
-    lanugage: PropTypes.string,
+    language: PropTypes.string,
     label: PropTypes.string,
     defaultOpen: PropTypes.bool,
   }

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,6 @@
 :root {
+  color-scheme: light dark;
+
   --m-white: #e6e6e7;
   --m-blue: #33a0d1;
   --m-purple: #373485;

--- a/src/pages/Playground/FFXIVStrat/index.jsx
+++ b/src/pages/Playground/FFXIVStrat/index.jsx
@@ -77,7 +77,7 @@ function FFXIVStrat() {
       )}
 
       {result && (
-        <SourceCode open language="json" label="decoded">
+        <SourceCode defaultOpen language="json" label="decoded">
           {JSON.stringify(result, null, 2)}
         </SourceCode>
       )}

--- a/src/pages/Playground/ImageData/index.mdx
+++ b/src/pages/Playground/ImageData/index.mdx
@@ -12,7 +12,7 @@ export default layout('ImageData - caasih.net', 'playground-use-image-data')
 把一個 React Hook 搬到這裡，它叫 `useImageData` 。
 
 <Picture />
-<SourceCode open language="jsx">
+<SourceCode defaultOpen language="jsx">
   {useImageDataSource}
 </SourceCode>
 
@@ -37,7 +37,7 @@ CPS 變換這裡就不贅述，從 2011 開始寫 js 的大家肯定是知道的
 同理，善用 `requestAnimationFrame` 與 React Hook ，也可以拚出各種按時間變化的值。
 
 <System />
-<SourceCode open language="jsx">
+<SourceCode defaultOpen language="jsx">
   {SystemSource}
 </SourceCode>
 

--- a/src/pages/Playground/Map/MinimumMap/index.jsx
+++ b/src/pages/Playground/Map/MinimumMap/index.jsx
@@ -84,9 +84,9 @@ class MinimumMap extends Component {
                       e.stopPropagation()
 
                       const pt = { x: e.clientX, y: e.clientY }
+                      const { startPoint } = this.state
                       actions.dragEnd()
 
-                      const { startPoint } = this.state
                       if (
                         Math.abs(startPoint.x - pt.x) < Number.EPSILON &&
                         Math.abs(startPoint.y - pt.y) < Number.EPSILON

--- a/src/pages/Playground/PureScript/index.jsx
+++ b/src/pages/Playground/PureScript/index.jsx
@@ -23,7 +23,7 @@ class PureScript extends React.PureComponent {
         </Helmet>
         <h1>PureScript</h1>
         <p>自從上次練習 VAT 驗證後，就再也沒碰過 PureScript 。最近好想用支援 ADT 的語言，撿回來學看看 XD</p>
-        <SourceCode open language="haskell">
+        <SourceCode defaultOpen language="haskell">
           {PreludeSource}
         </SourceCode>
         <CreativeCommons size="compact" type="by" />

--- a/src/pages/Playground/ReactKonva/TagList.jsx
+++ b/src/pages/Playground/ReactKonva/TagList.jsx
@@ -17,22 +17,26 @@ class TagList extends React.Component {
     }
   }
 
+  resizeHandlers = []
+
   getDimension(index) {
     return this.state.dimensions[index] || { width: 0, height: 0 }
   }
 
   setDimension(index, { width = 0, height = 0 } = {}) {
-    const { dimensions } = this.state
     const dimension = { width, height }
-    dimensions[index] = dimension
-    this.setState({ dimensions })
+    this.setState(({ dimensions }) => ({
+      dimensions: Object.assign([], dimensions, { [index]: dimension }),
+    }))
     return dimension
   }
 
   handleResize(index) {
-    return (width, height) => {
-      return this.setDimension(index, { width, height })
+    if (!this.resizeHandlers[index]) {
+      this.resizeHandlers[index] = (width, height) =>
+        this.setDimension(index, { width, height })
     }
+    return this.resizeHandlers[index]
   }
 
   render() {

--- a/src/pages/Playground/ReactKonva/index.jsx
+++ b/src/pages/Playground/ReactKonva/index.jsx
@@ -73,20 +73,20 @@ class ReactKonva extends React.Component {
         <p>
           下面提到的元件都以 <a href="https://flow.org/">Flow</a> 標註型別，有著類似結構：
         </p>
-        <SourceCode open language="jsx">
+        <SourceCode defaultOpen language="jsx">
           {componentStructure}
         </SourceCode>
         <hr />
         <p>
           為了取得文字寬高，得用上 <a href="https://reactjs.org/docs/refs-and-the-dom.html"><code>ref</code></a> 來存取 React 包裝起來的繪製結果。平常取得的 <code>ref</code> 是 DOM node ，在 React Konva 下，我們拿到的是 <a href="https://konvajs.github.io/api/Konva.Text.html"><code>Konva.Text</code></a> 。
         </p>
-        <SourceCode open language="jsx">
+        <SourceCode defaultOpen language="jsx">
           {ref}
         </SourceCode>
         <p>
           接著在 <code>componentDidMount</code> 和 <code>componentDidUpdate</code> 時，就可以將長寬回報給父元件。
         </p>
-        <SourceCode open language="jsx">
+        <SourceCode defaultOpen language="jsx">
           {handleResize}
         </SourceCode>
         <p>
@@ -100,7 +100,7 @@ class ReactKonva extends React.Component {
             <code>Text</code> 畫完後，再根據其長寬畫外框
           </figcaption>
         </figure>
-        <SourceCode open language="jsx">
+        <SourceCode defaultOpen language="jsx">
           {updateDimension}
         </SourceCode>
         <hr />

--- a/src/pages/Playground/UseLess/index.css
+++ b/src/pages/Playground/UseLess/index.css
@@ -25,6 +25,8 @@
           outline: none;
           padding: 0.5rem 1rem;
           border: 1px solid #ccc;
+          font: inherit;
+          line-height: 1;
         }
 
         input {

--- a/src/pages/Playground/UseLess/index.css
+++ b/src/pages/Playground/UseLess/index.css
@@ -14,6 +14,50 @@
       margin-bottom: 0 !important;
     }
 
+    fieldset {
+      display: flex;
+      gap: 0.25rem;
+      border: 0;
+      padding: 0;
+      margin: 0 0 0.75em;
+    }
+
+    fieldset input,
+    fieldset button {
+      font: inherit;
+      padding: 0.4rem 0.75rem;
+      border: 1px solid #ccc;
+      border-radius: 0.25rem;
+      background: #fff;
+      color: inherit;
+    }
+
+    fieldset input {
+      flex: 1;
+    }
+
+    fieldset button {
+      cursor: pointer;
+      background: #09f;
+      border-color: #09f;
+      color: #fff;
+    }
+
+    ol {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    ol li {
+      width: fit-content;
+      padding: 0.35rem 0.75rem;
+      margin-bottom: 0.25rem;
+      background: #09f;
+      color: #fff;
+      border-radius: 0.75rem;
+    }
+
     div {
       line-height: 0;
     }

--- a/src/pages/Playground/UseLess/index.css
+++ b/src/pages/Playground/UseLess/index.css
@@ -1,5 +1,6 @@
 .className {
   .demo {
+    color-scheme: light;
     background: #fcfcfc;
     padding: 0.5em;
     margin: 1em 0;

--- a/src/pages/Playground/UseLess/index.css
+++ b/src/pages/Playground/UseLess/index.css
@@ -14,66 +14,6 @@
       margin-bottom: 0 !important;
     }
 
-    section {
-      fieldset {
-        border: 0;
-        margin: 0;
-        margin-bottom: 1em;
-        padding: 0;
-
-        input, button {
-          box-sizing: content-box;
-          outline: none;
-          padding: 0.5rem 1rem;
-          border: 1px solid #ccc;
-          font: inherit;
-          line-height: 1;
-        }
-
-        input {
-          border-right-width: 0;
-        }
-
-        button {
-          border-color: #09f;
-          background-color: #09f;
-          color: #fff;
-        }
-      }
-
-      ol {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-
-        list-style: none;
-        padding-left: 0;
-        margin: 0;
-
-        li {
-          padding: 0.5rem 1rem;
-          line-height: 1rem;
-          background-color: #09f;
-          color: #fff;
-          border-top-right-radius: 1rem;
-          border-top-left-radius: 0.2rem;
-          border-bottom-right-radius: 1rem;
-          border-bottom-left-radius: 0.2rem;
-          margin-bottom: 0.2rem;
-
-          &:first-child {
-            border-top-left-radius: 1rem;
-
-          }
-
-          &:last-child {
-            border-bottom-left-radius: 1rem;
-            margin-bottom: 0;
-          }
-        }
-      }
-    }
-
     div {
       line-height: 0;
     }

--- a/src/pages/Playground/UseLess/index.jsx
+++ b/src/pages/Playground/UseLess/index.jsx
@@ -81,7 +81,7 @@ function AboutUseLess({ id, className }) {
 
       <p>當應用程式狀態更新時， <code>useState</code> hook 讓我們無視時間，拿到最新的值，好像我們一開始看到的就是最後的值一樣。</p>
       <p>換個角度看，也可以說 <code>useState</code> 幫我們把值攤到時間上了。例如可以寫一個 <code>useArray</code> ，把陣列中的值變成一系列更新：</p>
-      <SourceCode open language="js">
+      <SourceCode defaultOpen language="js">
         {useArraySource}
       </SourceCode>
       <p>
@@ -99,7 +99,7 @@ function AboutUseLess({ id, className }) {
       <h3><code>useSpace</code></h3>
       <p>但既然能把值攤到時間上，能不能反過來把時間上的變化，蒐集起來呢？</p>
       <p>可以設計一個 <code>useSpace</code> hook ：</p>
-      <SourceCode open language="js">
+      <SourceCode defaultOpen language="js">
         {useSpaceSource}
       </SourceCode>
       <p>於是我們又把 <code>{x}</code> 變回了 <code>[{takeFromUndefined(xss).join(', ')}]</code> 。</p>
@@ -110,7 +110,7 @@ function AboutUseLess({ id, className }) {
       <p>
         有了 <code>useSpace</code> ，我們可以：
       </p>
-      <SourceCode open language="js">
+      <SourceCode defaultOpen language="js">
         {useWebSocketPart}
       </SourceCode>
       <p>於是 <code>handleMessage</code> 不用看到整個 <code>messages</code> 。</p>
@@ -148,14 +148,14 @@ function AboutUseLess({ id, className }) {
 
       <h3><code>&lt;SpaceTime /&gt;</code></h3>
       <p>我們還可以做出這樣的 component ：</p>
-      <SourceCode open language="jsx">
+      <SourceCode defaultOpen language="jsx">
         {SpaceTimeSource}
       </SourceCode>
       <p><code>&lt;SpaceTime /&gt;</code> 展開過去繪製過的 children ，於是這樣寫：</p>
-      <SourceCode open language="jsx">
+      <SourceCode defaultOpen language="jsx">
         {ColorRectSource}
       </SourceCode>
-      <SourceCode open language="jsx">
+      <SourceCode defaultOpen language="jsx">
         {SpaceTimeExample}
       </SourceCode>
       <p>就能達成下面的效果：</p>
@@ -179,11 +179,11 @@ function AboutUseLess({ id, className }) {
 
       <h3><code>map</code></h3>
       <p>既然我們可以把值攤到時間上再組合回來，就可以把 <code>Array::map</code> 藏起來：</p>
-      <SourceCode open language="jsx">
+      <SourceCode defaultOpen language="jsx">
         {ListSource}
       </SourceCode>
       <p>再一口氣畫完一張圖：</p>
-      <SourceCode open language="jsx">
+      <SourceCode defaultOpen language="jsx">
         {ListExample}
       </SourceCode>
       <div className={styles.demo}>

--- a/src/pages/Playground/UseLess/use-array.js
+++ b/src/pages/Playground/UseLess/use-array.js
@@ -8,7 +8,9 @@ export default function useArray(xs) {
   }, [xs]);
 
   useEffect(() => {
-    if (index < xs.length - 1) setIndex(index + 1);
+    if (index >= xs.length - 1) return;
+    const id = requestAnimationFrame(() => setIndex(i => i + 1));
+    return () => cancelAnimationFrame(id);
   }, [xs, index]);
 
   return xs[index];

--- a/src/pages/Playground/WebVR/index.jsx
+++ b/src/pages/Playground/WebVR/index.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import cx from 'classnames'
 import { Helmet } from 'react-helmet'
 import Article from 'components/Article'
@@ -146,7 +146,8 @@ function FrameData({
 
 function AboutWebVR({ id, className }) {
   const classes = cx(styles.className, 'playground-web-vr', className)
-  const [ds = [], error, pending] = usePromise(useMemo(getVRDisplays, []))
+  const [displaysPromise] = useState(getVRDisplays)
+  const [ds = [], error, pending] = usePromise(displaysPromise)
   const foo = { foo: 'bar', baz: { bar: 'foo' } }
 
   return (

--- a/src/pages/Playground/WebVR/index.jsx
+++ b/src/pages/Playground/WebVR/index.jsx
@@ -10,7 +10,7 @@ new WebVRPolyfill()
 
 function getVRDisplays() {
   if (!('getVRDisplays' in navigator)) {
-    return Promise.reject('WebVR not supported')
+    return Promise.reject(new Error('WebVR not supported'))
   }
   return navigator.getVRDisplays()
 }


### PR DESCRIPTION
## Summary

First pass over `src/` driven by the `/old-react` review skill, plus a
small dark-mode form-control fix that surfaced while testing.

### React refactors

- `fix(react-konva)` immutable update for `TagList.state.dimensions` and
  cached per-index resize handlers — the previous code mutated the state
  array in place and produced a fresh handler factory per render,
  defeating PureComponent bail-outs in both directions.
- `fix(web-vr)` move `navigator.getVRDisplays()` out of render via a
  one-shot `useState` initializer.
- `fix(useless)` drive `useArray` index advance from `requestAnimationFrame`
  instead of a render-reentry `setIndex` chain.
- `fix(minmap)` capture `startPoint` before dispatching `dragEnd` so the
  click-vs-drag check no longer races a pending setState.
- `refactor(source-code)` rename `<SourceCode open>` to
  `<SourceCode defaultOpen>` to make the one-shot initial-value contract
  explicit (16 call sites updated).

### Theme + websocket demo

- `fix(theme)` declare `color-scheme: light dark` on `:root` so form
  controls follow OS dark mode.
- `fix(useless)` pin the `.demo` light card to `color-scheme: light` so
  nested inputs match the surrounding card.
- `style(useless)` tighten the websocket demo: flex fieldset, matched
  input/button heights, simpler bubble list.

## Test plan

- [x] `yarn test` (103/103 pass)
- [x] Manual: `/playground/web-vr` still resolves displays
- [x] Manual: `/playground/useless` typing still walks chars; rAF colors flicker on mouse-down; bubbles render
- [x] Manual: `/playground/map` drag-pan, click-select, bounding box
- [x] Manual: `/playground/react-konva` TagList wraps with even gaps
- [x] Manual: any `<SourceCode>` toggle still expands/collapses
- [x] Manual: dark OS mode → input fields readable everywhere